### PR TITLE
Add English comments and UI text

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,6 +4,7 @@ import keyboard
 app = Flask(__name__)
 
 # Mapea cada botón a una lista de secuencias de teclas
+# Map each button to a list of key sequences
 key_sequences = {
     '1': ['alt+n'],
     '2': ['alt+c'],
@@ -22,6 +23,7 @@ key_sequences = {
 @app.route('/')
 def index():
     # Pasa el mapping a la plantilla
+    # Pass the mapping to the template
     return render_template('index.html', key_sequences=key_sequences)
 
 @app.route('/press/<btn_id>', methods=['POST'])
@@ -31,6 +33,7 @@ def press(btn_id):
         return jsonify({'status': 'error', 'message': 'Botón no definido'}), 404
 
     # Ejecuta cada combinación de teclas
+    # Execute each key combination
     for combo in seq:
         keyboard.press_and_release(combo)
     return jsonify({'status': 'ok', 'pressed': seq})
@@ -38,4 +41,6 @@ def press(btn_id):
 if __name__ == '__main__':
     # Atención: es necesario ejecutar con privilegios en algunos sistemas
     # para que keyboard funcione correctamente.
+    # Note: on some systems you must run with elevated privileges
+    # for the keyboard library to work properly.
     app.run(host='0.0.0.0', port=8000)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Control de Teclas Remoto</title>
+<title>Remote Key Control Panel / Control de Teclas Remoto</title>
   <!-- Bootstrap CSS desde CDN -->
   <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
@@ -18,13 +18,13 @@
 </head>
 <body>
 
-  <h1 class="text-center mb-4">Panel de Control de Teclas</h1>
+  <h1 class="text-center mb-4">Panel de Control de Teclas / Remote Key Control Panel</h1>
   <div class="grid">
     {% for id, seq in key_sequences.items() %}
       <button
         class="btn btn-primary btn-custom"
         onclick="sendPress('{{ id }}')">
-        Botón {{ id }}<br>
+        Botón {{ id }} / Button {{ id }}<br>
         <small>{{ seq | join(' + ') }}</small>
       </button>
     {% endfor %}
@@ -36,14 +36,14 @@
         .then(r => r.json())
         .then(resp => {
           if (resp.status === 'ok') {
-            console.log(`Pulsadas: ${resp.pressed.join(', ')}`);
+            console.log(`Pulsadas: ${resp.pressed.join(', ')} / Pressed: ${resp.pressed.join(', ')}`);
           } else {
             alert('Error: ' + resp.message);
           }
         })
         .catch(err => {
           console.error(err);
-          alert('No se pudo conectar al servidor.');
+          alert('No se pudo conectar al servidor / Could not connect to the server.');
         });
     }
   </script>


### PR DESCRIPTION
## Summary
- include English translations next to Spanish comments
- add English text in the HTML interface

## Testing
- `python -m py_compile app/app.py`
- `pytest || true`

------
https://chatgpt.com/codex/tasks/task_e_6878547d69e4832990195a99f16f7f75