### PR TITLE
Implement send_key_sequence

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,6 +21,20 @@ def send_key_combo(combo: str) -> None:
     else:
         pyautogui.hotkey(*keys)
 
+
+def send_key_sequence(text: str) -> None:
+    """Send a whitespace separated sequence of key combinations.
+
+    Each segment in ``text`` represents a combination in ``ctrl+alt+del`` style
+    syntax and will be executed in order.
+    """
+    text = text.strip()
+    if not text:
+        return
+
+    for combo in text.split():
+        send_key_combo(combo)
+
 # Mapea cada botón a una lista de secuencias de teclas
 # Map each button to a list of key sequences
 key_sequences = {
@@ -50,10 +64,9 @@ def press(btn_id):
     if not seq:
         return jsonify({'status': 'error', 'message': 'Botón no definido'}), 404
 
-    # Ejecuta cada combinación de teclas
-    # Execute each key combination
-    for combo in seq:
-        send_key_combo(combo)
+    # Envía la secuencia de teclas completa usando send_key_sequence
+    # Send the entire key sequence using send_key_sequence
+    send_key_sequence(" ".join(seq))
     return jsonify({'status': 'ok', 'pressed': seq})
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `send_key_sequence` helper that executes combos using pyautogui
- call `send_key_sequence` from `/press/<btn_id>` route

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68787a5100e08329b15e4b60c82ccda0