### PR TITLE
Persist list of dynamic button ids

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -141,8 +141,11 @@ def press(btn_id):
     provide the sequence directly, so we simply execute it.
     """
 
-    data = request.get_json(silent=True) or {}
-    seq_text = data.get('seq', '')
+    data = request.get_json(silent=True)
+    if data and 'seq' in data:
+        seq_text = data.get('seq', '')
+    else:
+        seq_text = request.values.get('seq', '')
 
     if btn_id in buttons:
         seq = seq_text.split() if seq_text else buttons[btn_id]['seq']

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -289,8 +289,11 @@
       const addBtn = document.getElementById('addButton');
       if (addBtn) addBtn.addEventListener('click', addNewButton);
 
-      const ids = getIdList() || Object.keys(defaults);
-      if (!getIdList()) saveIdList(ids);
+      let ids = getIdList();
+      if (!ids) {
+        ids = Object.keys(defaults);
+        saveIdList(ids);
+      }
 
       ids.forEach(id => {
         const saved = loadConfig(id) || {};


### PR DESCRIPTION
## Summary
- read button id list from localStorage on startup
- fall back to defaults if nothing stored
- allow `/press/<btn_id>` to accept sequences for ids not defined server-side

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879558fb40883299eba7887b8cf08e9