### PR TITLE
Add trash icon to delete form entries

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,6 +10,9 @@
     rel="stylesheet"
     integrity="sha384-..."
     crossorigin="anonymous">
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+    rel="stylesheet">
   <style>
     body { padding: 1rem; }
     .btn-custom {
@@ -142,7 +145,9 @@
       form.innerHTML = `
           <div class="d-flex justify-content-between align-items-center mb-2">
             <h6 class="mb-0">Bot\u00f3n ${id}</h6>
-            <button type="button" class="btn btn-danger btn-sm delete-btn">&#128465;</button>
+            <button type="button" class="btn btn-outline-danger btn-sm delete-btn">
+              <i class="bi bi-trash"></i>
+            </button>
           </div>
           <div class="mb-2">
             <label class="form-label">Etiqueta / Label</label>


### PR DESCRIPTION
## Summary
- load Bootstrap Icons for UI icons
- show a trash icon button in each config form
- keep deletion confirmation logic intact

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68795e7edc508329b98beb1a143f8919