### PR TITLE
Add deletion confirmation modal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@ Objetivo: Transformar la interfaz en una cuadrícula dinámica, responsiva y vis
 
 - [ ] Agregar botón "Añadir nuevo botón" que cree un nuevo bloque editable en el panel de configuración.
 - [ ] Agregar ícono de papelera o botón “Eliminar” por cada botón en la interfaz de configuración.
-- [ ] Agregar confirmación antes de eliminar un botón (modal de Bootstrap o JS simple).
+- [x] Agregar confirmación antes de eliminar un botón (modal de Bootstrap o JS simple).
 
 ---
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -81,6 +81,24 @@
   <h1 class="text-center mb-4">Panel de Control de Teclas / Remote Key Control Panel</h1>
     <div class="grid" id="buttonGrid"></div>
 
+    <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Confirmar eliminaci\u00f3n</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            \u00bfEliminar este bot\u00f3n?
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="button" class="btn btn-danger" id="confirmDeleteYes">Eliminar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   <script>
     function sendPress(id) {
       const btn = document.querySelector(`[data-btn="${id}"]`);
@@ -118,6 +136,29 @@
       } catch (e) {
         return null;
       }
+    }
+
+    function confirmDeletion() {
+      const modalEl = document.getElementById('confirmDeleteModal');
+      const modal = new bootstrap.Modal(modalEl);
+      const yesBtn = document.getElementById('confirmDeleteYes');
+      return new Promise(resolve => {
+        const onConfirm = () => {
+          cleanup();
+          resolve(true);
+        };
+        const onHidden = () => {
+          cleanup();
+          resolve(false);
+        };
+        function cleanup() {
+          yesBtn.removeEventListener('click', onConfirm);
+          modalEl.removeEventListener('hidden.bs.modal', onHidden);
+        }
+        yesBtn.addEventListener('click', onConfirm, { once: true });
+        modalEl.addEventListener('hidden.bs.modal', onHidden, { once: true });
+        modal.show();
+      });
     }
     const defaults = {{ buttons | tojson }};
 
@@ -212,25 +253,26 @@
         });
       };
 
-      if (deleteBtn) {
-        deleteBtn.addEventListener('click', () => {
-          if (!confirm('¿Eliminar este botón?')) return;
-          form.remove();
-          button.remove();
-          localStorage.removeItem('config_' + id);
-          const ids = getIdList() || [];
-          const idx = ids.indexOf(id);
-          if (idx !== -1) {
-            ids.splice(idx, 1);
-            saveIdList(ids);
-          }
-          fetch(`/config/${id}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ seq: '' })
-          }).catch(() => {});
-        });
-      }
+        if (deleteBtn) {
+          deleteBtn.addEventListener('click', async () => {
+            const confirmed = await confirmDeletion();
+            if (!confirmed) return;
+            form.remove();
+            button.remove();
+            localStorage.removeItem('config_' + id);
+            const ids = getIdList() || [];
+            const idx = ids.indexOf(id);
+            if (idx !== -1) {
+              ids.splice(idx, 1);
+              saveIdList(ids);
+            }
+            fetch(`/config/${id}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ seq: '' })
+            }).catch(() => {});
+          });
+        }
 
       labelSpan.textContent = labelInput.value;
       seqDisplay.textContent = seqInput.value.split(' ').join(' + ');


### PR DESCRIPTION
## Summary
- add Bootstrap modal for confirming deletions
- hook deletion workflow to modal and clean up localStorage
- mark TODO task as complete

## Testing
- `python -m py_compile app/app.py`
- `pip install -r requirements.txt`
- `python app/app.py` *(fails: KeyError 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_687962bd5fac83298cea98be6ae4d872