### PR TITLE
Fix deletion modal hide logic

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -143,13 +143,14 @@
       const modal = new bootstrap.Modal(modalEl);
       const yesBtn = document.getElementById('confirmDeleteYes');
       return new Promise(resolve => {
+        let confirmed = false;
         const onConfirm = () => {
-          cleanup();
-          resolve(true);
+          confirmed = true;
+          bootstrap.Modal.getInstance(modalEl).hide();
         };
         const onHidden = () => {
           cleanup();
-          resolve(false);
+          resolve(confirmed);
         };
         function cleanup() {
           yesBtn.removeEventListener('click', onConfirm);


### PR DESCRIPTION
## Summary
- hide confirmation modal before resolving deletion promise

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687973b3ca848329881f5f7b2d8eca9a