### PR TITLE
Allow multi-action sequences

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,3 +28,22 @@ On Linux, additional system packages like `python3-xlib` may be required for `py
 ## Using the interface
 
 The web page displays a grid of buttons. Each button corresponds to a sequence of keys defined in `app/app.py`. Clicking a button sends a request to the server, which then presses and releases the configured keys on the host machine.
+
+### Multiple actions per button
+
+You can configure a button to execute several key combinations in order. In the
+configuration panel, enter one combination per line, for example:
+
+```
+ctrl+c
+ctrl+v
+```
+
+The server will press `Ctrl+C` followed by `Ctrl+V`. The API also accepts JSON
+arrays of actions:
+
+```bash
+curl -X POST http://localhost:8000/press/1 \
+     -H 'Content-Type: application/json' \
+     -d '{"seq": ["ctrl+c", "ctrl+v"]}'
+```

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -167,7 +167,7 @@
       const btn = document.createElement('button');
       btn.className = 'btn btn-primary btn-custom';
       btn.dataset.btn = id;
-      btn.dataset.seq = (cfg.seq || []).join(' ');
+      btn.dataset.seq = (cfg.seq || []).join('\n');
       btn.onclick = () => sendPress(id);
       if (cfg.image) {
         btn.style.backgroundImage = `url('${cfg.image}')`;
@@ -212,7 +212,7 @@
           </div>
           <div class="mb-2">
             <label class="form-label">Secuencia / Sequence</label>
-            <input type="text" class="form-control seq-input" value="${(cfg.seq || []).join(' ')}">
+            <textarea class="form-control seq-input" rows="3">${(cfg.seq || []).join('\n')}</textarea>
           </div>`;
       return form;
     }
@@ -276,7 +276,7 @@
         }
 
       labelSpan.textContent = labelInput.value;
-      seqDisplay.textContent = seqInput.value.split(' ').join(' + ');
+      seqDisplay.textContent = seqInput.value.split(/\s+/).join(' + ');
       button.dataset.seq = seqInput.value.trim();
 
       toggleGroups();
@@ -321,7 +321,7 @@
             .then(r => r.json())
             .then(resp => {
               if (resp.status === 'ok') {
-                seqDisplay.textContent = seq.split(' ').join(' + ');
+                seqDisplay.textContent = seq.split(/\s+/).join(' + ');
                 button.dataset.seq = seq;
               }
             })


### PR DESCRIPTION
## Summary
- let `send_key_sequence` accept lists of combos
- parse lists or strings in `/press/<id>` and `/config/<id>`
- allow multi-line sequences in config UI
- document multiple action usage in the README

## Testing
- `python -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687988a679d08329b4b81e50eaa1ba8a