### PR TITLE
Add wait command support

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,26 +25,49 @@ def send_key_combo(combo: str) -> None:
 def send_key_sequence(seq) -> None:
     """Send a sequence of key combinations.
 
-    ``seq`` can be either a whitespace separated string or a list of strings. In
-    string form, any whitespace (spaces, newlines) is treated as a separator. Each
-    resulting token must use the ``"ctrl+alt+del"`` syntax, where ``+`` denotes
-    simultaneous key presses.
+    ``seq`` can be either a whitespace separated string or a list of
+    strings. In string form, any whitespace (spaces, newlines) is treated
+    as a separator. Each resulting token must use the ``"ctrl+alt+del"``
+    syntax, where ``+`` denotes simultaneous key presses. Tokens of the
+    form ``wait <ms>`` (optionally written ``wait100`` or ``wait100ms``)
+    insert a pause of the specified milliseconds between key combos.
     """
 
     if isinstance(seq, str):
         text = seq.strip()
         if not text:
             return
-        combos = text.split()
+        tokens = text.split()
     elif isinstance(seq, list):
-        combos = [str(c).strip() for c in seq if str(c).strip()]
-        if not combos:
+        tokens = [str(c).strip() for c in seq if str(c).strip()]
+        if not tokens:
             return
     else:
         return
 
-    for combo in combos:
-        send_key_combo(combo)
+    import re
+    import time
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+
+        # Pattern: "wait", optional next token with numbers, or
+        # forms like "wait100" or "wait100ms"
+        if token == "wait" and i + 1 < len(tokens):
+            m = re.match(r"^(\d+)(?:ms)?$", tokens[i + 1])
+            if m:
+                time.sleep(int(m.group(1)) / 1000)
+                i += 2
+                continue
+        m = re.match(r"^wait(\d+)(?:ms)?$", token)
+        if m:
+            time.sleep(int(m.group(1)) / 1000)
+            i += 1
+            continue
+
+        send_key_combo(token)
+        i += 1
 
 # Map each button to its configuration including
 # the key sequence, optional background image and

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -213,6 +213,7 @@
           <div class="mb-2">
             <label class="form-label">Secuencia / Sequence</label>
             <textarea class="form-control seq-input" rows="3">${(cfg.seq || []).join('\n')}</textarea>
+            <div class="form-text">Ej: <code>ctrl+c wait 500 ctrl+v</code> &mdash; usa <code>wait &lt;ms&gt;</code> para pausar.</div>
           </div>`;
       return form;
     }

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch
+import sys, types
+
+# Provide a dummy pyautogui so app.app can be imported without X server
+mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)
+sys.modules['pyautogui'] = mock_pg
+
+from app.app import send_key_sequence
+
+class WaitParseTests(unittest.TestCase):
+    def run_seq(self, seq):
+        combos = []
+        sleeps = []
+        with patch('app.app.send_key_combo', side_effect=lambda c: combos.append(c)):
+            with patch('time.sleep', side_effect=lambda t: sleeps.append(t)):
+                send_key_sequence(seq)
+        return combos, sleeps
+
+    def test_wait_next_token(self):
+        combos, sleeps = self.run_seq('a wait 1000 b')
+        self.assertEqual(combos, ['a', 'b'])
+        self.assertEqual(sleeps, [1.0])
+
+    def test_wait_single_token(self):
+        combos, sleeps = self.run_seq('a wait500ms b')
+        self.assertEqual(combos, ['a', 'b'])
+        self.assertEqual(sleeps, [0.5])
+
+    def test_list_input(self):
+        combos, sleeps = self.run_seq(['a', 'wait', '200', 'b'])
+        self.assertEqual(combos, ['a', 'b'])
+        self.assertEqual(sleeps, [0.2])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `wait` tokens in `send_key_sequence`
- show hint in configuration UI for pauses
- add unit tests for wait parsing

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68798f468b4083298758c8aefad5843f