### PR TITLE
Add shell command actions

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,8 @@
 from flask import Flask, render_template, jsonify, request
 import pyautogui
+import subprocess
+import shlex
+import re
 
 # Disable the fail-safe feature so moving the mouse to a corner
 # doesn't raise an exception during automated key presses.
@@ -69,78 +72,112 @@ def send_key_sequence(seq) -> None:
         send_key_combo(token)
         i += 1
 
+
+SAFE_CMD = re.compile(r'^[\w\-./ ]+$')
+
+
+def run_shell_command(cmd: str):
+    """Run a shell command safely with basic validation."""
+    if not isinstance(cmd, str) or not SAFE_CMD.fullmatch(cmd.strip()):
+        raise ValueError('Unsafe command')
+    return subprocess.run(shlex.split(cmd), capture_output=True, text=True)
+
 # Map each button to its configuration including
 # the key sequence, optional background image and
 # a customizable label to display on the UI
 buttons = {
     '1': {
         'label': 'Botón 1 / Button 1',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['alt+n'],
         'image': None,
         'color': '#f8d7da'
     },
     '2': {
         'label': 'Botón 2 / Button 2',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['alt+c'],
         'image': None,
         'color': '#d1e7dd'
     },
     '3': {
         'label': 'Botón 3 / Button 3',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['n'],
         'image': None,
         'color': None
     },
     '4': {
         'label': 'Botón 4 / Button 4',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['1'],
         'image': None,
         'color': None
     },
     '5': {
         'label': 'Botón 5 / Button 5',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['ctrl+a'],
         'image': None,
         'color': None
     },
     '6': {
         'label': 'Botón 6 / Button 6',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['ctrl+c'],
         'image': None,
         'color': None
     },
     '7': {
         'label': 'Botón 7 / Button 7',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['ctrl+v'],
         'image': None,
         'color': None
     },
     '8': {
         'label': 'Botón 8 / Button 8',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['f5'],
         'image': None,
         'color': None
     },
     '9': {
         'label': 'Botón 9 / Button 9',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['esc'],
         'image': None,
         'color': None
     },
     '10': {
         'label': 'Botón 10 / Button 10',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['enter'],
         'image': None,
         'color': None
     },
     '11': {
         'label': 'Botón 11 / Button 11',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['tab'],
         'image': None,
         'color': None
     },
     '12': {
         'label': 'Botón 12 / Button 12',
+        'type': 'keys',
+        'cmd': '',
         'seq': ['space'],
         'image': None,
         'color': None
@@ -155,19 +192,24 @@ def index():
 
 @app.route('/config/<btn_id>', methods=['POST'])
 def update_config(btn_id):
-    """Update the key sequence for a button."""
+    """Update the configuration for a button."""
     btn = buttons.get(btn_id)
     if not btn:
         return jsonify({'status': 'error', 'message': 'Botón no definido'}), 404
 
     data = request.get_json(silent=True) or {}
-    seq_val = data.get('seq', '')
-    if isinstance(seq_val, list):
-        btn['seq'] = [str(s).strip() for s in seq_val if str(s).strip()]
+    btn['type'] = data.get('type', btn.get('type', 'keys'))
+    if btn['type'] == 'shell':
+        btn['cmd'] = str(data.get('cmd', '')).strip()
+        return jsonify({'status': 'ok', 'type': 'shell', 'cmd': btn['cmd']})
     else:
-        seq_text = str(seq_val)
-        btn['seq'] = seq_text.split() if seq_text.strip() else []
-    return jsonify({'status': 'ok', 'seq': btn['seq']})
+        seq_val = data.get('seq', '')
+        if isinstance(seq_val, list):
+            btn['seq'] = [str(s).strip() for s in seq_val if str(s).strip()]
+        else:
+            seq_text = str(seq_val)
+            btn['seq'] = seq_text.split() if seq_text.strip() else []
+        return jsonify({'status': 'ok', 'type': 'keys', 'seq': btn['seq']})
 
 @app.route('/press/<btn_id>', methods=['POST'])
 def press(btn_id):
@@ -179,18 +221,32 @@ def press(btn_id):
     provide the sequence directly, so we simply execute it.
     """
 
-    data = request.get_json(silent=True)
-    if data and 'seq' in data:
-        seq_val = data.get('seq')
-    else:
-        seq_val = request.values.get('seq')
+    data = request.get_json(silent=True) or {}
+    req_type = data.get('type') or request.values.get('type') or 'keys'
+    cmd_val = data.get('cmd') or request.values.get('cmd')
+    seq_val = data.get('seq') if 'seq' in data else request.values.get('seq')
 
     if btn_id in buttons:
-        seq = seq_val if seq_val not in (None, '') else buttons[btn_id]['seq']
+        cfg = buttons[btn_id]
+        action = req_type or cfg.get('type', 'keys')
+        if action == 'shell':
+            cmd = cmd_val if cmd_val not in (None, '') else cfg.get('cmd')
+            if not cmd:
+                return jsonify({'status': 'error', 'message': 'Comando vacío'}), 400
+            result = run_shell_command(cmd)
+            return jsonify({'status': 'ok', 'stdout': result.stdout})
+        else:
+            seq = seq_val if seq_val not in (None, '') else cfg.get('seq')
     else:
-        if seq_val in (None, ''):
-            return jsonify({'status': 'error', 'message': 'Botón no definido'}), 404
-        seq = seq_val
+        if req_type == 'shell':
+            if not cmd_val:
+                return jsonify({'status': 'error', 'message': 'Comando vacío'}), 400
+            result = run_shell_command(cmd_val)
+            return jsonify({'status': 'ok', 'stdout': result.stdout})
+        else:
+            if seq_val in (None, ''):
+                return jsonify({'status': 'error', 'message': 'Botón no definido'}), 404
+            seq = seq_val
 
     send_key_sequence(seq)
     pressed = seq if isinstance(seq, list) else str(seq).split()

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -106,11 +106,17 @@
         btn.classList.add('active-anim');
         setTimeout(() => btn.classList.remove('active-anim'), 200);
       }
+      const type = btn?.dataset.type || 'keys';
       const seq = btn?.dataset.seq || '';
+      const cmd = btn?.dataset.cmd || '';
+      if (type === 'shell') {
+        if (!cmd) return;
+        if (!confirm(`Ejecutar comando:\n${cmd}?`)) return;
+      }
       fetch(`/press/${id}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ seq })
+        body: JSON.stringify({ type, seq, cmd })
       })
         .then(r => r.json())
         .then(resp => {
@@ -167,7 +173,9 @@
       const btn = document.createElement('button');
       btn.className = 'btn btn-primary btn-custom';
       btn.dataset.btn = id;
+      btn.dataset.type = cfg.type || 'keys';
       btn.dataset.seq = (cfg.seq || []).join('\n');
+      btn.dataset.cmd = cfg.cmd || '';
       btn.onclick = () => sendPress(id);
       if (cfg.image) {
         btn.style.backgroundImage = `url('${cfg.image}')`;
@@ -175,7 +183,8 @@
       } else if (cfg.color) {
         btn.style.backgroundColor = cfg.color;
       }
-      btn.innerHTML = `<span class="btn-label">${cfg.label}</span><br><small class="seq-display">${(cfg.seq || []).join(' + ')}</small>`;
+      const display = btn.dataset.type === 'shell' ? (cfg.cmd || '') : (cfg.seq || []).join(' + ');
+      btn.innerHTML = `<span class="btn-label">${cfg.label}</span><br><small class="seq-display">${display}</small>`;
       return btn;
     }
 
@@ -196,6 +205,13 @@
             <input type="text" class="form-control label-input" value="${cfg.label}">
           </div>
           <div class="mb-2">
+            <label class="form-label">Tipo de acción</label>
+            <select class="form-select action-type">
+              <option value="keys"${(cfg.type || 'keys') === 'keys' ? ' selected' : ''}>Secuencia de teclas</option>
+              <option value="shell"${cfg.type === 'shell' ? ' selected' : ''}>Comando shell</option>
+            </select>
+          </div>
+          <div class="mb-2">
             <label class="form-label">Fondo</label>
             <select class="form-select bg-choice">
               <option value="image"${bgType === 'image' ? ' selected' : ''}>Imagen</option>
@@ -210,10 +226,14 @@
             <label class="form-label">Color</label>
             <input type="color" class="form-control form-control-color" value="${cfg.color || '#ffffff'}">
           </div>
-          <div class="mb-2">
+          <div class="mb-2 seq-group${(cfg.type || 'keys') === 'keys' ? '' : ' d-none'}">
             <label class="form-label">Secuencia / Sequence</label>
             <textarea class="form-control seq-input" rows="3">${(cfg.seq || []).join('\n')}</textarea>
             <div class="form-text">Ej: <code>ctrl+c wait 500 ctrl+v</code> &mdash; usa <code>wait &lt;ms&gt;</code> para pausar.</div>
+          </div>
+          <div class="mb-2 cmd-group${cfg.type === 'shell' ? '' : ' d-none'}">
+            <label class="form-label">Comando</label>
+            <input type="text" class="form-control cmd-input" value="${cfg.cmd || ''}">
           </div>`;
       return form;
     }
@@ -223,7 +243,11 @@
       const bgSelect = form.querySelector('.bg-choice');
       const imgInput = form.querySelector('.image-group input');
       const colorInput = form.querySelector('.color-group input');
+      const typeSelect = form.querySelector('.action-type');
       const seqInput = form.querySelector('.seq-input');
+      const cmdInput = form.querySelector('.cmd-input');
+      const seqGroup = form.querySelector('.seq-group');
+      const cmdGroup = form.querySelector('.cmd-group');
       const deleteBtn = form.querySelector('.delete-btn');
 
       const labelSpan = button.querySelector('.btn-label');
@@ -232,6 +256,8 @@
       const toggleGroups = () => {
         form.querySelector('.image-group').classList.toggle('d-none', bgSelect.value !== 'image');
         form.querySelector('.color-group').classList.toggle('d-none', bgSelect.value !== 'color');
+        seqGroup.classList.toggle('d-none', typeSelect.value !== 'keys');
+        cmdGroup.classList.toggle('d-none', typeSelect.value !== 'shell');
       };
 
       const applyStyles = () => {
@@ -251,7 +277,9 @@
           bg: bgSelect.value,
           image: imgInput.value.trim(),
           color: colorInput.value,
-          seq: seqInput.value.trim()
+          type: typeSelect.value,
+          seq: seqInput.value.trim(),
+          cmd: cmdInput.value.trim()
         });
       };
 
@@ -277,22 +305,31 @@
         }
 
       labelSpan.textContent = labelInput.value;
-      seqDisplay.textContent = seqInput.value.split(/\s+/).join(' + ');
+      seqDisplay.textContent = typeSelect.value === 'shell' ? cmdInput.value : seqInput.value.split(/\s+/).join(' + ');
       button.dataset.seq = seqInput.value.trim();
+      button.dataset.type = typeSelect.value;
+      button.dataset.cmd = cmdInput.value.trim();
 
       toggleGroups();
       applyStyles();
 
-      if (seqInput.value.trim()) {
+      if (seqInput.value.trim() || cmdInput.value.trim()) {
         fetch(`/config/${id}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ seq: seqInput.value.trim() })
+          body: JSON.stringify({ type: typeSelect.value, seq: seqInput.value.trim(), cmd: cmdInput.value.trim() })
         }).catch(() => {});
       }
 
       labelInput.addEventListener('input', () => {
         labelSpan.textContent = labelInput.value;
+        saveCurrent();
+      });
+
+      typeSelect.addEventListener('change', () => {
+        toggleGroups();
+        seqDisplay.textContent = typeSelect.value === 'shell' ? cmdInput.value : seqInput.value.split(/\s+/).join(' + ');
+        button.dataset.type = typeSelect.value;
         saveCurrent();
       });
 
@@ -312,23 +349,39 @@
         saveCurrent();
       });
 
-        seqInput.addEventListener('change', () => {
-          const seq = seqInput.value.trim();
+      seqInput.addEventListener('change', () => {
+        const seq = seqInput.value.trim();
+        fetch(`/config/${id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: typeSelect.value, seq, cmd: cmdInput.value.trim() })
+        })
+          .then(r => r.json())
+          .then(resp => {
+            if (resp.status === 'ok') {
+              seqDisplay.textContent = typeSelect.value === 'shell' ? cmdInput.value : seq.split(/\s+/).join(' + ');
+              button.dataset.seq = seq;
+              button.dataset.type = typeSelect.value;
+            }
+          })
+          .catch(() => {});
+        saveCurrent();
+      });
+
+      if (cmdInput) {
+        cmdInput.addEventListener('change', () => {
+          const cmd = cmdInput.value.trim();
           fetch(`/config/${id}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ seq })
-          })
-            .then(r => r.json())
-            .then(resp => {
-              if (resp.status === 'ok') {
-                seqDisplay.textContent = seq.split(/\s+/).join(' + ');
-                button.dataset.seq = seq;
-              }
-            })
-            .catch(() => {});
-        saveCurrent();
-      });
+            body: JSON.stringify({ type: typeSelect.value, seq: seqInput.value.trim(), cmd })
+          }).catch(() => {});
+          seqDisplay.textContent = typeSelect.value === 'shell' ? cmd : seqInput.value.split(/\s+/).join(' + ');
+          button.dataset.cmd = cmd;
+          button.dataset.type = typeSelect.value;
+          saveCurrent();
+        });
+      }
     }
 
     function getIdList() {
@@ -356,7 +409,7 @@
       const newId = generateId(ids);
       ids.push(newId);
       saveIdList(ids);
-      const cfg = { label: `Botón ${newId}`, seq: [], image: '', color: '', bg: 'color' };
+      const cfg = { label: `Botón ${newId}`, seq: [], cmd: '', type: 'keys', image: '', color: '', bg: 'color' };
       saveConfig(newId, cfg);
       const button = createButton(newId, cfg);
       grid.appendChild(button);
@@ -385,6 +438,8 @@
           image: saved.image !== undefined ? saved.image : def.image,
           color: saved.color !== undefined ? saved.color : def.color,
           seq: saved.seq ? saved.seq.trim().split(/\s+/) : (def.seq || []),
+          cmd: saved.cmd !== undefined ? saved.cmd : (def.cmd || ''),
+          type: saved.type || def.type || 'keys',
           bg: saved.bg || (saved.image ? 'image' : (saved.color ? 'color' : (def.image ? 'image' : 'color')))
         };
         const button = createButton(id, cfg);

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
-import sys, types
+import sys, types, os
+# Ensure repo root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # Provide a dummy pyautogui so app.app can be imported without X server
 mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys, types, os
+# Ensure repo root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Mock pyautogui to import app.app
+mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)
+sys.modules['pyautogui'] = mock_pg
+
+from app.app import run_shell_command
+
+class ShellCommandTests(unittest.TestCase):
+    def test_valid_command(self):
+        mock_proc = MagicMock(stdout='ok', returncode=0)
+        with patch('subprocess.run', return_value=mock_proc) as run:
+            result = run_shell_command('echo test')
+            run.assert_called_once()
+            self.assertEqual(result, mock_proc)
+
+    def test_invalid_command_chars(self):
+        with self.assertRaises(ValueError):
+            run_shell_command('rm -rf /; echo hi')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow shell commands in button configuration
- handle shell command execution safely server-side
- support configuring command or key sequence in the UI
- confirm before executing shell commands
- test shell command helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879907fce9883299b7519c026461200