### PR TITLE
Add keyboard backend abstraction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,12 @@ The server listens on port **8000**. Open `http://localhost:8000` in your browse
 
 ## Notes on privileges
 
-The application relies on [`pyautogui`](https://pypi.org/project/pyautogui/) to emulate key presses. Depending on your operating system, sending key events may require administrator or root privileges. If you find that key presses are not working, try running the program with elevated permissions.
+The application relies on a small module (`keyboard_backend.py`) to send key events. It detects the host operating system when the server starts. `pyautogui` is used on all platforms, but on Windows the backend will try to use `pywin32` (or the `SendInput` API) if it is available. Depending on your OS, sending key events may require administrator or root privileges. If you find that key presses are not working, try running the program with elevated permissions.
+
+### OS support
+
+* **Windows** – Works with `pyautogui`. Installing `pywin32` enables the alternate backend that uses the native `SendInput` API.
+* **Linux/macOS** – Uses `pyautogui`. Additional packages such as `python3-xlib` may be required on Linux.
 
 On Linux, additional system packages like `python3-xlib` may be required for `pyautogui` to function correctly.
 

--- a/keyboard_backend.py
+++ b/keyboard_backend.py
@@ -1,0 +1,106 @@
+import sys
+from types import SimpleNamespace
+
+_backend_name = 'pyautogui'
+_platform = sys.platform
+
+try:
+    if _platform.startswith('win'):
+        import win32api
+        import win32con
+        # Map basic keys to Virtual-Key codes
+        VK = {
+            'ctrl': win32con.VK_CONTROL,
+            'alt': win32con.VK_MENU,
+            'shift': win32con.VK_SHIFT,
+            'win': win32con.VK_LWIN,
+            'enter': win32con.VK_RETURN,
+            'tab': win32con.VK_TAB,
+            'esc': win32con.VK_ESCAPE,
+            'space': win32con.VK_SPACE,
+        }
+        for c in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':
+            VK[c.lower()] = getattr(win32con, f'VK_{c}')
+        for n in range(10):
+            VK[str(n)] = getattr(win32con, f'VK_{n}')
+        for n in range(1, 13):
+            VK[f'f{n}'] = getattr(win32con, f'VK_F{n}')
+
+        def key_down(k):
+            vk = VK.get(k.lower())
+            if vk is None:
+                raise ValueError(f'Unsupported key: {k}')
+            win32api.keybd_event(vk, 0, 0, 0)
+
+        def key_up(k):
+            vk = VK.get(k.lower())
+            if vk is None:
+                raise ValueError(f'Unsupported key: {k}')
+            win32api.keybd_event(vk, 0, win32con.KEYEVENTF_KEYUP, 0)
+
+        def press(k):
+            key_down(k)
+            key_up(k)
+
+        def hotkey(*keys):
+            for k in keys:
+                key_down(k)
+            for k in reversed(keys):
+                key_up(k)
+
+        backend = SimpleNamespace(press=press, hotkey=hotkey)
+        _backend_name = 'pywin32'
+    else:
+        raise ImportError
+except Exception:
+    import pyautogui
+    pyautogui.FAILSAFE = False
+    backend = pyautogui
+    _backend_name = 'pyautogui'
+
+
+def send_key_combo(combo: str) -> None:
+    keys = combo.split('+')
+    if len(keys) == 1:
+        backend.press(keys[0])
+    else:
+        backend.hotkey(*keys)
+
+
+def send_key_sequence(seq) -> None:
+    if isinstance(seq, str):
+        text = seq.strip()
+        if not text:
+            return
+        tokens = text.split()
+    elif isinstance(seq, list):
+        tokens = [str(c).strip() for c in seq if str(c).strip()]
+        if not tokens:
+            return
+    else:
+        return
+
+    import time
+    import re
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == 'wait' and i + 1 < len(tokens):
+            m = re.match(r'^(\d+)(?:ms)?$', tokens[i + 1])
+            if m:
+                time.sleep(int(m.group(1)) / 1000)
+                i += 2
+                continue
+        m = re.match(r'^wait(\d+)(?:ms)?$', token)
+        if m:
+            time.sleep(int(m.group(1)) / 1000)
+            i += 1
+            continue
+
+        send_key_combo(token)
+        i += 1
+
+
+BACKEND_NAME = _backend_name
+PLATFORM = _platform

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -8,13 +8,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)
 sys.modules['pyautogui'] = mock_pg
 
-from app.app import send_key_sequence
+from keyboard_backend import send_key_sequence
 
 class WaitParseTests(unittest.TestCase):
     def run_seq(self, seq):
         combos = []
         sleeps = []
-        with patch('app.app.send_key_combo', side_effect=lambda c: combos.append(c)):
+        with patch('keyboard_backend.send_key_combo', side_effect=lambda c: combos.append(c)):
             with patch('time.sleep', side_effect=lambda t: sleeps.append(t)):
                 send_key_sequence(seq)
         return combos, sleeps


### PR DESCRIPTION
## Summary
- add `keyboard_backend.py` with Windows/pyautogui handling
- update `app/app.py` to use new backend and log platform
- adjust tests for new import path
- document OS support and backend info

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687995eafdf08329b87f074419af4dc7