### PR TITLE
Add pyautogui backend tests and update cross‑platform docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,9 +26,9 @@ The application relies on a small module (`keyboard_backend.py`) to send key eve
 ### OS support
 
 * **Windows** – Works with `pyautogui`. Installing `pywin32` enables the alternate backend that uses the native `SendInput` API.
-* **Linux/macOS** – Uses `pyautogui`. Additional packages such as `python3-xlib` may be required on Linux.
+* **Linux/macOS** – Uses `pyautogui`. On Linux you must also install `python3-xlib` (via pip or your package manager). On macOS `pyobjc` (or `pyobjc-core`/`pyobjc-framework-Quartz`) is needed so `pyautogui` can access the accessibility APIs.
 
-On Linux, additional system packages like `python3-xlib` may be required for `pyautogui` to function correctly.
+On Linux, additional system packages like `python3-xlib` may be required for `pyautogui` to function correctly. macOS users should ensure the `pyobjc` dependencies are installed.
 
 ## Using the interface
 

--- a/keyboard_backend.py
+++ b/keyboard_backend.py
@@ -2,7 +2,15 @@ import sys
 from types import SimpleNamespace
 
 _backend_name = 'pyautogui'
-_platform = sys.platform
+_platform_raw = sys.platform
+if _platform_raw.startswith('win'):
+    _platform = 'windows'
+elif _platform_raw.startswith('linux'):
+    _platform = 'linux'
+elif _platform_raw == 'darwin':
+    _platform = 'darwin'
+else:
+    _platform = _platform_raw
 
 try:
     if _platform.startswith('win'):
@@ -53,7 +61,13 @@ try:
     else:
         raise ImportError
 except Exception:
-    import pyautogui
+    try:
+        import pyautogui
+    except Exception as exc:
+        raise ImportError(
+            'pyautogui is required on non-Windows platforms. ' \
+            'Install python3-Xlib on Linux or pyobjc on macOS.'
+        ) from exc
     pyautogui.FAILSAFE = False
     backend = pyautogui
     _backend_name = 'pyautogui'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 flask
 pyautogui
+python3-Xlib; sys_platform == 'linux'
+pyobjc-core; sys_platform == 'darwin'
+pyobjc; sys_platform == 'darwin'
 requests

--- a/tests/test_backend_platforms.py
+++ b/tests/test_backend_platforms.py
@@ -1,0 +1,31 @@
+import importlib.util
+import os
+import sys
+import types
+from unittest import TestCase, mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+class BackendPlatformTests(TestCase):
+    def _load_backend(self, platform):
+        spec = importlib.util.spec_from_file_location('kb_temp', os.path.join(ROOT, 'keyboard_backend.py'))
+        module = importlib.util.module_from_spec(spec)
+        dummy_pg = types.SimpleNamespace(FAILSAFE=False, press=mock.Mock(), hotkey=mock.Mock())
+        with mock.patch.object(sys, 'platform', platform):
+            with mock.patch.dict('sys.modules', {'pyautogui': dummy_pg}):
+                spec.loader.exec_module(module)
+        return module, dummy_pg
+
+    def test_linux_uses_pyautogui(self):
+        kb, dummy = self._load_backend('linux')
+        kb.send_key_combo('a')
+        dummy.press.assert_called_once_with('a')
+        self.assertEqual(kb.BACKEND_NAME, 'pyautogui')
+        self.assertEqual(kb.PLATFORM, 'linux')
+
+    def test_darwin_uses_pyautogui(self):
+        kb, dummy = self._load_backend('darwin')
+        kb.send_key_combo('b')
+        dummy.press.assert_called_once_with('b')
+        self.assertEqual(kb.BACKEND_NAME, 'pyautogui')
+        self.assertEqual(kb.PLATFORM, 'darwin')


### PR DESCRIPTION
## Summary
- add explicit platform detection to `keyboard_backend.py`
- raise helpful error when pyautogui dependencies are missing
- document Linux/macOS prereqs in README
- list platform specific packages in requirements
- test pyautogui backend on Linux and macOS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687997708b1c8329aa6f6ef14c413e0f