### PR TITLE
Add bootstrap toast feedback for button actions

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -64,6 +64,7 @@
   </style>
 </head>
 <body>
+  <div id="toastContainer" class="toast-container position-fixed top-0 end-0 p-3"></div>
 
   <button id="configBtn" class="btn btn-secondary" data-bs-toggle="offcanvas" data-bs-target="#configPanel" aria-controls="configPanel">⚙</button>
 
@@ -129,6 +130,17 @@
         setTimeout(() => button.classList.remove('active-anim'), 200);
       }
     }
+    function showToast(message, variant = "success") {
+      const container = document.getElementById("toastContainer");
+      const toastEl = document.createElement("div");
+      toastEl.className = `toast align-items-center text-bg-${variant} border-0`;
+      toastEl.setAttribute("role", "alert");
+      toastEl.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+      container.appendChild(toastEl);
+      const toast = new bootstrap.Toast(toastEl, { delay: 3000 });
+      toastEl.addEventListener("hidden.bs.toast", () => toastEl.remove());
+      toast.show();
+    }
     function sendPress(id) {
       const btn = document.querySelector(`[data-btn="${id}"]`);
       const type = btn?.dataset.type || 'keys';
@@ -151,17 +163,18 @@
           if (resp.status === 'ok') {
             playEffect(btn);
             if (type === 'http') {
-              alert(`HTTP ${method} -> ${resp.status_code}`);
+              showToast(`HTTP ${method} -> ${resp.status_code}`);
             } else {
+              showToast('Acción ejecutada / Action executed');
               console.log(`Pulsadas: ${resp.pressed.join(', ')} / Pressed: ${resp.pressed.join(', ')}`);
             }
           } else {
-            alert('Error: ' + resp.message);
+            showToast('Error: ' + resp.message, 'danger');
           }
         })
         .catch(err => {
           console.error(err);
-          alert('No se pudo conectar al servidor / Could not connect to the server.');
+          showToast('No se pudo conectar al servidor / Could not connect to the server.', 'danger');
         });
     }
 


### PR DESCRIPTION
## Summary
- add a bootstrap toast container in `index.html`
- add helper `showToast()` to trigger small toast messages
- display toast notifications when button actions succeed or fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d5be467c8329a6cf2ba6b938c7b0