### PR TITLE
Add special key mapping support

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -325,7 +325,7 @@
           <div class="mb-2 seq-group${(cfg.type || 'keys') === 'keys' ? '' : ' d-none'}">
             <label class="form-label">Secuencia / Sequence</label>
             <textarea class="form-control seq-input" rows="3">${(cfg.seq || []).join('\n')}</textarea>
-            <div class="form-text">Ej: <code>ctrl+c wait 500 ctrl+v</code> &mdash; usa <code>wait &lt;ms&gt;</code> para pausar.</div>
+            <div class="form-text">Ej: <code>ctrl+c wait 500 ctrl+v</code> &mdash; usa <code>wait &lt;ms&gt;</code> para pausar. Teclas especiales: <code>f1</code>&ndash;<code>f12</code>, <code>left_click</code>, <code>right_click</code>, <code>numpad_0</code>&ndash;<code>numpad_9</code>.</div>
           </div>
           <div class="mb-2 cmd-group${cfg.type === 'shell' ? '' : ' d-none'}">
             <label class="form-label">Comando</label>

--- a/tests/test_key_mappings.py
+++ b/tests/test_key_mappings.py
@@ -1,0 +1,36 @@
+import importlib.util
+import os
+import sys
+import types
+from unittest import TestCase, mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+class KeyMappingTests(TestCase):
+    def _load_backend(self):
+        spec = importlib.util.spec_from_file_location('kb_temp', os.path.join(ROOT, 'keyboard_backend.py'))
+        module = importlib.util.module_from_spec(spec)
+        dummy_pg = types.SimpleNamespace(
+            FAILSAFE=False,
+            press=mock.Mock(),
+            hotkey=mock.Mock(),
+            click=mock.Mock(),
+        )
+        with mock.patch.dict('sys.modules', {'pyautogui': dummy_pg}):
+            spec.loader.exec_module(module)
+        return module, dummy_pg
+
+    def test_numpad_mapping(self):
+        kb, dummy = self._load_backend()
+        kb.send_key_combo('numpad_0')
+        dummy.press.assert_called_once_with('num0')
+
+    def test_mouse_click_mapping(self):
+        kb, dummy = self._load_backend()
+        kb.send_key_combo('left_click')
+        dummy.click.assert_called_once_with(button='left')
+
+    def test_function_key(self):
+        kb, dummy = self._load_backend()
+        kb.send_key_combo('f1')
+        dummy.press.assert_called_once_with('f1')


### PR DESCRIPTION
## Summary
- support mouse clicks and numpad keys in `send_key_combo`
- mention the new key names in the UI help
- add tests for the special key mappings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d7b88bf88329bd2bcbd86b63ba15