### PR TITLE
Fix direct app execution import

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,8 @@
 from flask import Flask, render_template, jsonify, request
+import os
 import sys
+# Ensure imports work when running the script directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import keyboard_backend as kb
 import subprocess
 import shlex


### PR DESCRIPTION
## Summary
- adjust `app/app.py` to add the repository root to `sys.path`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d7c302148329baaea6bc4b2cfb83