### PR TITLE
Improve shell command validation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -16,9 +16,9 @@ SAFE_CMD = re.compile(r'^[\w\-./ ]+$')
 
 
 def run_shell_command(cmd: str):
-    """Run a shell command safely with basic validation."""
+    """Run a shell command after validating it against ``SAFE_CMD``."""
     if not isinstance(cmd, str) or not SAFE_CMD.fullmatch(cmd.strip()):
-        raise ValueError('Unsafe command')
+        raise ValueError('Command rejected')
     return subprocess.run(shlex.split(cmd), capture_output=True, text=True)
 
 # Map each button to its configuration including
@@ -253,7 +253,10 @@ def press(btn_id):
             cmd = cmd_val if cmd_val not in (None, '') else cfg.get('cmd')
             if not cmd:
                 return jsonify({'status': 'error', 'message': 'Comando vacío'}), 400
-            result = run_shell_command(cmd)
+            try:
+                result = run_shell_command(cmd)
+            except ValueError as exc:
+                return jsonify({'status': 'error', 'message': str(exc)}), 400
             return jsonify({'status': 'ok', 'stdout': result.stdout})
         elif action == 'http':
             method = (method_val or cfg.get('method', 'GET')).upper()
@@ -272,7 +275,10 @@ def press(btn_id):
         if req_type == 'shell':
             if not cmd_val:
                 return jsonify({'status': 'error', 'message': 'Comando vacío'}), 400
-            result = run_shell_command(cmd_val)
+            try:
+                result = run_shell_command(cmd_val)
+            except ValueError as exc:
+                return jsonify({'status': 'error', 'message': str(exc)}), 400
             return jsonify({'status': 'ok', 'stdout': result.stdout})
         elif req_type == 'http':
             if not url_val:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -8,9 +8,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)
 sys.modules['pyautogui'] = mock_pg
 
-from app.app import run_shell_command
+from app.app import run_shell_command, app, buttons
 
 class ShellCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
     def test_valid_command(self):
         mock_proc = MagicMock(stdout='ok', returncode=0)
         with patch('subprocess.run', return_value=mock_proc) as run:
@@ -21,6 +24,12 @@ class ShellCommandTests(unittest.TestCase):
     def test_invalid_command_chars(self):
         with self.assertRaises(ValueError):
             run_shell_command('rm -rf /; echo hi')
+
+    def test_press_invalid_command(self):
+        buttons['1']['type'] = 'shell'
+        resp = self.client.post('/press/1', json={'type': 'shell', 'cmd': 'rm -rf /; echo hi'})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()['status'], 'error')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle invalid shell commands in the `/press` API
- return an error message if validation fails
- add regression test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d9a88cc48329887679c1b2e2a183