### PR TITLE
Use ctypes SendInput backend

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,11 +21,11 @@ The server listens on port **8000**. Open `http://localhost:8000` in your browse
 
 ## Notes on privileges
 
-The application relies on a small module (`keyboard_backend.py`) to send key events. It detects the host operating system when the server starts. `pyautogui` is used on all platforms, but on Windows the backend will try to use `pywin32` (or the `SendInput` API) if it is available. Depending on your OS, sending key events may require administrator or root privileges. If you find that key presses are not working, try running the program with elevated permissions.
+The application relies on a small module (`keyboard_backend.py`) to send key events. It detects the host operating system when the server starts. `pyautogui` is used on all platforms, but on Windows key presses are sent using the native `SendInput` API directly. Installing `pywin32` is optional. Depending on your OS, sending key events may require administrator or root privileges. If you find that key presses are not working, try running the program with elevated permissions.
 
 ### OS support
 
-* **Windows** – Works with `pyautogui`. Installing `pywin32` enables the alternate backend that uses the native `SendInput` API.
+* **Windows** – Works with `pyautogui`. Key events use the native `SendInput` API directly, so `pywin32` is optional.
 * **Linux/macOS** – Uses `pyautogui`. On Linux you must also install `python3-xlib` (via pip or your package manager). On macOS `pyobjc` (or `pyobjc-core`/`pyobjc-framework-Quartz`) is needed so `pyautogui` can access the accessibility APIs.
 
 On Linux, additional system packages like `python3-xlib` may be required for `pyautogui` to function correctly. macOS users should ensure the `pyobjc` dependencies are installed.

--- a/tests/test_backend_platforms.py
+++ b/tests/test_backend_platforms.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 import types
+import ctypes
 from unittest import TestCase, mock
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -16,6 +17,15 @@ class BackendPlatformTests(TestCase):
                 spec.loader.exec_module(module)
         return module, dummy_pg
 
+    def _load_backend_win(self, send_mock):
+        spec = importlib.util.spec_from_file_location('kb_temp', os.path.join(ROOT, 'keyboard_backend.py'))
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.object(sys, 'platform', 'win32'):
+            windll = types.SimpleNamespace(user32=types.SimpleNamespace(SendInput=send_mock))
+            with mock.patch.object(ctypes, 'windll', windll, create=True):
+                spec.loader.exec_module(module)
+        return module
+
     def test_linux_uses_pyautogui(self):
         kb, dummy = self._load_backend('linux')
         kb.send_key_combo('a')
@@ -29,3 +39,22 @@ class BackendPlatformTests(TestCase):
         dummy.press.assert_called_once_with('b')
         self.assertEqual(kb.BACKEND_NAME, 'pyautogui')
         self.assertEqual(kb.PLATFORM, 'darwin')
+
+    def test_windows_sendinput_called(self):
+        send_mock = mock.Mock(return_value=1)
+        kb = self._load_backend_win(send_mock)
+        kb.send_key_combo('a')
+        self.assertEqual(kb.BACKEND_NAME, 'sendinput')
+        self.assertEqual(kb.PLATFORM, 'windows')
+        self.assertEqual(send_mock.call_count, 2)
+
+        args1 = send_mock.call_args_list[0][0]
+        ptr1 = ctypes.cast(args1[1], ctypes.POINTER(kb.INPUT))
+        self.assertEqual(args1[0], 1)
+        self.assertEqual(ptr1.contents.ki.wVk, 0x41)
+        self.assertEqual(ptr1.contents.ki.dwFlags, 0)
+
+        args2 = send_mock.call_args_list[1][0]
+        ptr2 = ctypes.cast(args2[1], ctypes.POINTER(kb.INPUT))
+        self.assertEqual(ptr2.contents.ki.wVk, 0x41)
+        self.assertEqual(ptr2.contents.ki.dwFlags, kb.KEYEVENTF_KEYUP)


### PR DESCRIPTION
## Summary
- replace deprecated pywin32 backend with ctypes implementation
- clarify README that SendInput is called directly
- unit test for Windows backend via mocked SendInput

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e1be401c8329ab92c42109931a35