### PR TITLE
Implement safe mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+app/safe_mode.txt

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,10 +61,18 @@
       right: 1rem;
       z-index: 1050;
     }
+    #safeModeBtn {
+      position: fixed;
+      top: 1rem;
+      right: 4rem;
+      z-index: 1050;
+    }
   </style>
 </head>
 <body>
   <div id="toastContainer" class="toast-container position-fixed top-0 end-0 p-3"></div>
+
+  <button id="safeModeBtn" class="btn btn-success" title="Modo seguro"><i class="bi bi-unlock"></i></button>
 
   <button id="configBtn" class="btn btn-secondary" data-bs-toggle="offcanvas" data-bs-target="#configPanel" aria-controls="configPanel">⚙</button>
 
@@ -159,6 +167,26 @@
       toastEl.addEventListener("hidden.bs.toast", () => toastEl.remove());
       toast.show();
     }
+    let safeMode = false;
+    function updateSafeModeButton() {
+      const btn = document.getElementById('safeModeBtn');
+      if (!btn) return;
+      btn.innerHTML = safeMode ? '<i class="bi bi-lock-fill"></i>' : '<i class="bi bi-unlock"></i>';
+      btn.classList.toggle('btn-danger', safeMode);
+      btn.classList.toggle('btn-success', !safeMode);
+    }
+    function fetchSafeMode() {
+      return fetch('/safe_mode')
+        .then(r => r.json())
+        .then(d => { safeMode = d.enabled; updateSafeModeButton(); return safeMode; });
+    }
+    function setSafeMode(enabled) {
+      return fetch('/safe_mode', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled })
+      }).then(r => r.json()).then(d => { safeMode = d.enabled; updateSafeModeButton(); return safeMode; });
+    }
     function sendPress(id) {
       const btn = document.querySelector(`[data-btn="${id}"]`);
       const type = btn?.dataset.type || 'keys';
@@ -168,6 +196,10 @@
       const url = btn?.dataset.url || '';
       const bodyData = btn?.dataset.body || '';
       const critical = btn?.dataset.critical === 'true';
+      if (safeMode) {
+        showToast('Modo seguro activo', 'warning');
+        return;
+      }
       if (critical) {
         confirmCritical().then(accepted => {
           if (accepted) doSend();
@@ -803,7 +835,7 @@ function generateId(existing) {
       reader.readAsText(file);
     }
 
-    let configContainer, grid;
+  let configContainer, grid, safeModeBtn;
 
     function addNewButton() {
       const ids = getIdList() || Object.keys(defaults);
@@ -819,9 +851,18 @@ function generateId(existing) {
       setupForm(form, button, newId);
     }
 
-    window.addEventListener('DOMContentLoaded', () => {
+  window.addEventListener('DOMContentLoaded', () => {
       configContainer = document.getElementById('configContainer');
       grid = document.getElementById('buttonGrid');
+      safeModeBtn = document.getElementById('safeModeBtn');
+      if (safeModeBtn) {
+        safeModeBtn.addEventListener('click', () => {
+          setSafeMode(!safeMode).then(state => {
+            showToast(state ? 'Modo seguro activado' : 'Modo seguro desactivado', state ? 'warning' : 'success');
+          });
+        });
+      }
+      fetchSafeMode();
 
       const profileSelect = document.getElementById('profileSelect');
       const newProfileBtn = document.getElementById('newProfileBtn');

--- a/tests/test_safe_mode.py
+++ b/tests/test_safe_mode.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch
+import sys, types, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+mock_pg = types.SimpleNamespace(FAILSAFE=False, press=lambda *a, **k: None, hotkey=lambda *a, **k: None)
+sys.modules['pyautogui'] = mock_pg
+
+from app.app import app
+
+class SafeModeTests(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        self.client.post('/safe_mode', json={'enabled': False})
+
+    def tearDown(self):
+        self.client.post('/safe_mode', json={'enabled': False})
+
+    def test_press_blocked_when_enabled(self):
+        resp = self.client.post('/safe_mode', json={'enabled': True})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.get_json()['enabled'])
+        resp2 = self.client.post('/press/1', json={'type': 'keys'})
+        self.assertEqual(resp2.status_code, 403)
+        self.assertEqual(resp2.get_json()['status'], 'error')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add backend flag persisted in `safe_mode.txt`
- expose `/safe_mode` endpoint and block `/press` when enabled
- integrate safe mode toggle UI button and logic
- warn when pressing a button in safe mode
- ignore `safe_mode.txt` in git
- test safe mode functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e332fd848329b273dfac8c1ceb98