### PR TITLE
Add drag-and-drop button reordering

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -854,6 +854,19 @@ function generateId(existing) {
   window.addEventListener('DOMContentLoaded', () => {
       configContainer = document.getElementById('configContainer');
       grid = document.getElementById('buttonGrid');
+      if (typeof Sortable !== 'undefined') {
+        new Sortable(grid, {
+          animation: 150,
+          onEnd: () => {
+            const ids = Array.from(grid.children).map(el => el.dataset.btn);
+            saveIdList(ids);
+            ids.forEach(id => {
+              const f = configContainer.querySelector(`form[data-btn="${id}"]`);
+              if (f) configContainer.appendChild(f);
+            });
+          }
+        });
+      }
       safeModeBtn = document.getElementById('safeModeBtn');
       if (safeModeBtn) {
         safeModeBtn.addEventListener('click', () => {
@@ -974,6 +987,8 @@ function generateId(existing) {
     });
 
 </script>
+
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-..." crossorigin="anonymous"></script>
 


### PR DESCRIPTION
## Summary
- integrate SortableJS
- sync order changes to localStorage
- move config forms to match button order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e620b2d0832985f75dfae24a863b